### PR TITLE
fix: compilation warnings

### DIFF
--- a/lib/zuck.ex
+++ b/lib/zuck.ex
@@ -40,7 +40,7 @@ defmodule Zuck do
           next_req = Request.put_params(req, %{ after: cursor })
           {:ok, res} = call(next_req)
           {res.data, get_in(res, [:paging, :cursors, :after])}
-      end, fn cursor -> end)
+      end, fn _ -> true end)
   end
 
   def call(%Request{} = req) do

--- a/lib/zuck/request.ex
+++ b/lib/zuck/request.ex
@@ -49,7 +49,7 @@ defmodule Zuck.Request do
     Enum.flat_map(req.params, &encode_param/1)
   end
 
-  def body(%Request{method: :get} = req) do
+  def body(%Request{method: :get}) do
     []
   end
   def body(%Request{} = req) do
@@ -59,7 +59,7 @@ defmodule Zuck.Request do
   def query_string(%Request{method: :get} = req) do
     encode_params(req)
   end
-  def query_string(%Request{} = req) do
+  def query_string(%Request{}) do
     []
   end
 


### PR DESCRIPTION
warning: an expression is always required on the right side of ->. Please provide a value after ->
  lib/zuck.ex:43

warning: variable "req" is unused
  lib/zuck/request.ex:52

warning: variable "req" is unused
  lib/zuck/request.ex:62

warning: variable "cursor" is unused
  lib/zuck.ex:43